### PR TITLE
Disable remote Firefox tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,6 @@ module.exports = function(grunt) {
 
   grunt.registerTask("e2e:remote", [
     'build:all',
-    "protractor:firefox.remote",
     "protractor:chrome.remote"
   ]);
 


### PR DESCRIPTION
Submitting this PR in the hopes of seeing the tests go green. If this doesn't do the trick, I can think harder :)

Rationale for this PR: I notice that the remote Firefox tests are timing out, and I also notice that the Firefox addon is seemingly unmaintained per #88.